### PR TITLE
Fixing empty data responses for queries

### DIFF
--- a/src/inStorageCache.js
+++ b/src/inStorageCache.js
@@ -87,6 +87,7 @@ class InStorageCache extends InMemoryCache {
     }
 
     this.data = new ObjectStorageCache(null, this.persistence)
+    this.optimisticData = this.data
   }
 
   transformDocument (doc) {


### PR DESCRIPTION
https://github.com/TallerWebSolutions/apollo-cache-instorage/issues/6?_pjax=%23js-repo-pjax-container

InMemoryCache reads responses for queries from optimistic data which currently is empty. With this fix, the responses are read from the correct data set. InMemoryCache does something similar in overwriting both optimisticData and data